### PR TITLE
Handle case where element is SVG

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -38,6 +38,11 @@
                             classNames = element.className,
                             l = classList.length;
 
+                        // Unwrap SVGAnimatedString
+                        if (classNames && classNames.baseVal !== undefined) {
+                          classNames = classNames.baseVal;
+                        }
+
                         // loop through the elements id's and classnames looking for exceptions
                         for (i = 0; i < l; i++) {
                             // check for id's or classes, but only if they exist in the first place


### PR DESCRIPTION
This causes the 'className' property to be an instanceof SVGAnimatedString instead of simply a string. This can be handled by unwrapping the SVGAnimatedString.

I saw the same problem as in https://github.com/IamAdamJowett/angular-click-outside/issues/10, and this was the problem for me.