### PR TITLE
Removed return value from expression

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -61,7 +61,8 @@
                         // if we have got this far, then we are good to go with processing the command passed in via the click-outside attribute
                         return $scope.$apply(function() {
                             fn = $parse(attr['clickOutside']);
-                            return fn($scope);
+                            fn($scope);
+                            return;
                         });
                     }
 

--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -59,10 +59,9 @@
                         }
 
                         // if we have got this far, then we are good to go with processing the command passed in via the click-outside attribute
-                        return $scope.$apply(function() {
+                        $scope.$apply(function() {
                             fn = $parse(attr['clickOutside']);
                             fn($scope);
-                            return;
                         });
                     }
 


### PR DESCRIPTION
I removed the return value of the exception, as it created problems when the expression returns false and thus prevents browser default behviour.
Consider the following:
```html
<form ng-submit="doSomething()">
    <input type="submit">
</form>
```

And then at a completely different location on the page:
```html
<div id="some-unique-id" click-outside="someVariable=false">
```

The ngSubmit handler will not fire when the submit button is clicked because the clickOutside expression returns false. The same value is then returned by the eventHandler therefore preventing the browser default action for the MouseEvent and not firing the onsubmit event. See [this StackOverflow question](http://stackoverflow.com/questions/128923/whats-the-effect-of-adding-return-false-to-an-click-event-listener).

This is not only a problem with the submit handler but also with links. If any clickOutside handler on the page returns false, no links will be followed!

The fix is to not return the value returned by the angular expression passed to clickOutside. I am not aware of any other use for the return value of the expression, I therefore removed the return value completely.