### PR TITLE
fix : ousideIfNot with more than two values

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -14,7 +14,7 @@
                 
                 // postpone linking to next digest to allow for unique id generation
                 $timeout(function() {
-                    var classList = (attr.outsideIfNot !== undefined) ? attr.outsideIfNot.replace(', ', ',').split(',') : [],
+                    var classList = (attr.outsideIfNot !== undefined) ? attr.outsideIfNot.split(/[ ,]+/) : [],
                         fn;
 
                     // add the elements id so it is not counted in the click listening


### PR DESCRIPTION
.replace with a string only changes the first match, ignoring the rest.
.split can receive a regex to make up for that