### PR TITLE
Change $apply with $timeout to avoid $digest in progress error

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -73,7 +73,7 @@
                         }
 
                         // if we have got this far, then we are good to go with processing the command passed in via the click-outside attribute
-                        $scope.$apply(function() {
+                        $timeout(function() {
                             fn = $parse(attr['clickOutside']);
                             fn($scope);
                         });


### PR DESCRIPTION
When using this directive in bigger application you can get $digest in progress error.
`$timeout` directive will invoke `$apply` by itself, more detailed you can see here:
https://docs.angularjs.org/api/ng/service/$timeout

As you can see here https://github.com/angular/angular.js/wiki/Anti-Patterns it's an anti-pattern as well.