### PR TITLE
Update clickoutside.directive.js

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -42,6 +42,10 @@
 
                         // loop through the available elements, looking for classes in the class list that might match and so will eat
                         for (element = e.target; element; element = element.parentNode) {
+                            if (element === elem[0]) {
+                                return;
+                            }
+                            
                             id = element.id,
                             classNames = element.className,
                             l = classList.length;


### PR DESCRIPTION
fix clicking inside element.

i know that adding an id to element fixes the issue, but i find it stupid to put random ids on elements just for this component, comparing elements by reference is cheaper then getting and comparing ids or classes and other things.