### PR TITLE
added event in the callback.

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -83,7 +83,7 @@
                         // if we have got this far, then we are good to go with processing the command passed in via the click-outside attribute
                         $timeout(function() {
                             fn = $parse(attr['clickOutside']);
-                            fn($scope);
+                            fn($scope, { event: e });
                         });
                     }
 


### PR DESCRIPTION
It is convinient to have event in the callback function. I had problems with events bubbling and I resolved it with event.stopPropagation().