### PR TITLE
support id prefixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-click-outside",
-    "version": "2.10.2",
+    "version": "2.11.0",
     "main": "clickoutside.directive.js",
     "homepage": "https://github.com/IamAdamJowett/angular-click-outside",
     "authors": [

--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -9,7 +9,7 @@
             '$document', '$parse', '$timeout',
             clickOutside
         ]);
-    
+
     /**
      * @ngdoc directive
      * @name angular-click-outside.directive:clickOutside
@@ -52,7 +52,7 @@
                             if (element === elem[0]) {
                                 return;
                             }
-                            
+
                             // now we have done the initial checks, start gathering id's and classes
                             id = element.id,
                             classNames = element.className,
@@ -72,7 +72,7 @@
                                     r = new RegExp('\\b' + classList[i] + '\\b');
 
                                     // check for exact matches on id's or classes, but only if they exist in the first place
-                                    if ((id !== undefined && id === classList[i]) || (classNames && r.test(classNames))) {
+                                    if ((id !== undefined && r.test(id)) || (classNames && r.test(classNames))) {
                                         // now let's exit out as it is an element that has been defined as being ignored for clicking outside
                                         return;
                                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iamadamjowett/angular-click-outside",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "main": "clickoutside.directive.js",
   "author": {
     "name": "Adam Jowett",


### PR DESCRIPTION
the outside-if-not also supports id prefixes, so things like datepickers can simply be excluded 