### PR TITLE
Fixes issue with mobile devices where eventHandler would fire without…

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -89,7 +89,9 @@
 
                     // if the devices has a touchscreen, listen for this event
                     if (_hasTouch()) {
-                        $document.on('touchstart', eventHandler);
+                        $document.on('touchstart', function () {
+                          setTimeout(eventHandler)
+                        });
                     }
 
                     // still listen for the click event even if there is touch to cater for touchscreen laptops


### PR DESCRIPTION
Sometimes the element that we want to hide in consequence of "clicking outside" is also a clickable element and we want that element to hide but at the same time we want his event listeners to fire in response to a click action (just like in desktop devices). 

In mobile devices, the touchstart fires before any click event causing our element to be closed without letting his events listeners to fire.  To solve this issue I just wrapped our handler in a setTimeout.
