### PR TITLE
Skip linking if elemented already removed in the meantime

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -22,9 +22,18 @@
         return {
             restrict: 'A',
             link: function($scope, elem, attr) {
+                let isDestoyed = false;
+
+                $scope.$on('$destroy', function() {
+                  isDestoyed = true;
+                });
 
                 // postpone linking to next digest to allow for unique id generation
                 $timeout(function() {
+                    if (isDestoyed) {
+                        return;
+                    }
+
                     var classList = (attr.outsideIfNot !== undefined) ? attr.outsideIfNot.split(/[ ,]+/) : [],
                         fn;
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "iamadamjowett/angular-click-outside",
+  "name": "angular-click-outside",
   "version": "2.11.0",
   "main": "clickoutside.directive.js",
   "author": {


### PR DESCRIPTION
The edge case I've found was when:
* view with click-outside was quickly created & remeved - multiple times per second
* randomly there were listeners added for already removed controllers

My assumption was:

> it can be that with quick enough reloads we get:
> * linking delayed as:
> ```
> // postpone linking to next digest to allow for unique id generation               
> $timeout(function() {
> ```
> * destroy done in the same digest (if it's even possible), of poped in before the $timeout callback
> if this is true, checking if the scope exists before calling close should fix it.

the assumptions turned out to be right - double checking in the callback with:
```
      if ($scope.$$destroyed === true) {
        console.log('we are dead!');
        return;
      }
```
removed the issue form the application code.

In this PR I'm trying to address the rootcause issue