### PR TITLE
Cancel timers on $destroy event

### DIFF
--- a/clickoutside.directive.js
+++ b/clickoutside.directive.js
@@ -24,9 +24,10 @@
             link: function($scope, elem, attr) {
 
                 // postpone linking to next digest to allow for unique id generation
-                $timeout(function() {
+                var timer = $timeout(function() {
                     var classList = (attr.outsideIfNot !== undefined) ? attr.outsideIfNot.split(/[ ,]+/) : [],
-                        fn;
+                        fn,
+                        timer;
 
                     function eventHandler(e) {
                         var i,
@@ -81,7 +82,7 @@
                         }
 
                         // if we have got this far, then we are good to go with processing the command passed in via the click-outside attribute
-                        $timeout(function() {
+                        timer = $timeout(function() {
                             fn = $parse(attr['clickOutside']);
                             fn($scope, { event: e });
                         });
@@ -99,6 +100,8 @@
 
                     // when the scope is destroyed, clean up the documents event handlers as we don't want it hanging around
                     $scope.$on('$destroy', function() {
+                        if(timer) $timeout.cancel(timer);
+
                         if (_hasTouch()) {
                             $document.off('touchstart', eventHandler);
                         }
@@ -114,6 +117,10 @@
                         // works on most browsers, IE10/11 and Surface
                         return 'ontouchstart' in window || navigator.maxTouchPoints;
                     };
+                });
+
+                $scope.$on('$destroy', function() {
+                    if(timer) $timeout.cancel(timer);
                 });
             }
         };


### PR DESCRIPTION
The directive registers timers but doesn't cancel them when the directive $scope is destroyed. Even though the timers are set to triggered on the next event loop it can still give problems. I am not sure of the exact interactions that were causing my issue but I seemed to be related with the $scope being destroyed before the timeout triggered that would setup the event listener and $destroy handler. 

Under high loads when quickly creating/destroying scopes, sometimes it happened that the event handler was being registered but the corresponding $destroy handler didn't run upon the destroy of the corresponding scope.

I think its because the $scope was destroyed before the outer $timeout triggers. The solution is to setup a $destroy listener directly outside of the timeout to cancel the $timeout when the $scope is destroyed.

It would be nice if this could get merged :)
