### PR TITLE
Revert "Merge pull request #60 from koningskristof/patch-2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "iamadamjowett/angular-click-outside",
+  "name": "@iamadamjowett/angular-click-outside",
   "version": "2.11.0",
   "main": "clickoutside.directive.js",
   "author": {


### PR DESCRIPTION
Removing the '@' breaks the package entirely. It can't be installed without it.